### PR TITLE
Another candidate

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,9 @@ table {
   border-left: 1px solid rgba(0,0,0,.12);
   padding: 12px;
 }
+.mdl-data-table td.empty {
+  background-color: rgba(0,0,0,.12);
+}
 .mdl-data-table th {
   border-top: 0px;
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -143,53 +143,52 @@
         table.appendChild(tr);
       }
 
+      var timetableRows = new Array(Math.floor((actualLastDate - now) / 60000));
+      for (var i = 0; i < timetableRows.length; i++) {
+        timetableRows[i] = [];
+      }
       Object.keys(channels).forEach(function(key) {
         channels[key].forEach(function(programme) {
           var start = programme.startObj;
           if (start < now) {
             start = now;
           }
-          programme.pos = Math.floor((start - now) / 60000);
+          var pos = Math.floor((start - now) / 60000);
           programme.height = Math.floor((programme.stopObj - start) / 60000);
+          if (0 <= pos && pos < timetableRows.length) { // failsafe
+            timetableRows[pos].push(programme);
+          }
         });
       });
-
-      var timeTics = Math.floor((actualLastDate - now) / 60000);
-      for (var i = 0; i < timeTics; i++) {
+      for (var i = 0; i < timetableRows.length; i++) {
         var tr = document.createElement('tr');
-        Object.keys(channels).forEach(function(key) {
-          for (var j = 0; j < channels[key].length; j++) {
-            var programme = channels[key][j];
-            if (i == programme.pos) {
-              var td = document.createElement('td');
-              td.classList.add(remoconNumbers[key]);
-              td.classList.add('mdl-data-table__cell--non-numeric');
-              if (programme.title == "NO DATA") {
-                td.classList.add('empty');
-              } else {
-                var strong = document.createElement('strong');
-                strong.textContent = formatDate(programme.startObj);
-                td.appendChild(strong);
-                var text = document.createTextNode(' ' + programme.title);
-                td.appendChild(text);
-              }
-              td.setAttribute('valign', 'top');
-              td.setAttribute('rowspan', programme.height);
-              tr.appendChild(td);
-              programmes.splice(i, 1);
-              return;
-            }
-          };
+        timetableRows[i].forEach(function(programme) {
+          var td = document.createElement('td');
+          td.classList.add(programme.remocon_number);
+          td.classList.add('mdl-data-table__cell--non-numeric');
+          if (programme.title == "NO DATA") {
+            td.classList.add('empty');
+          } else {
+            var strong = document.createElement('strong');
+            strong.textContent = formatDate(programme.startObj);
+            td.appendChild(strong);
+            var text = document.createTextNode(' ' + programme.title);
+            td.appendChild(text);
+          }
+          td.setAttribute('valign', 'top');
+          td.setAttribute('rowspan', programme.height);
+          tr.appendChild(td);
         });
         table.appendChild(tr);
       }
       timetable.appendChild(table);
       getCurrentChannel();
 
-      if (typeof nextReloadTime === 'undefined' || nextReloadTime.getTime() <= 0) {
+      now = new Date(); // without setSeconds(0, 0)
+      if (typeof nextReloadTime === 'undefined' || nextReloadTime - now <= 0) {
         setTimeout(function() { updateProgrammes(); }, 5 * 60 * 1000);
       } else {
-        setTimeout(function() { updateProgrammes(); }, (nextReloadTime - (new Date())));
+        setTimeout(function() { updateProgrammes(); }, nextReloadTime - now);
       }
     });
   }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -67,9 +67,8 @@
       var now = new Date();
       now.setSeconds(0, 0);
       var lastDate = new Date(now.getTime() + 6 * 60 * 60 * 1000);
+
       var actualLastDate = now;
-      var table = document.createElement('table');
-      table.className = 'mdl-data-table';
       var channels = {};
       var remoconNumbers = {};
       programmes.forEach(function(programme) {
@@ -86,6 +85,7 @@
           channels[programme.name].push(programme);
         }
       });
+
       var nextReloadTime;
       Object.keys(channels).forEach(function(key) {
         var programmes = channels[key];
@@ -115,6 +115,9 @@
           nextReloadTime = firstProgrammeStop;
         }
       });
+
+      var table = document.createElement('table');
+      table.className = 'mdl-data-table';
       {
         var tr = document.createElement('tr');
         var width = (100 / Object.keys(channels).length) + '%';

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -155,11 +155,15 @@
                 var td = document.createElement('td');
                 td.classList.add(remoconNumber);
                 td.classList.add('mdl-data-table__cell--non-numeric');
-                var strong = document.createElement('strong');
-                strong.textContent = formatDate(start);
-                td.appendChild(strong);
-                var text = document.createTextNode(' ' + programme.title);
-                td.appendChild(text);
+                if (programme.title == "NO DATA") {
+                  td.classList.add('empty');
+                } else {
+                  var strong = document.createElement('strong');
+                  strong.textContent = formatDate(start);
+                  td.appendChild(strong);
+                  var text = document.createTextNode(' ' + programme.title);
+                  td.appendChild(text);
+                }
                 td.setAttribute('valign', 'top');
                 td.setAttribute('rowspan', height);
                 tr.appendChild(td);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -107,10 +107,10 @@
             i++;
           }
         }
-        var currentTime = new Date(programmes[0].stop);
+        var firstProgrammeStop = new Date(programmes[0].stop);
         if (typeof nextReloadTime === 'undefined'
-              || nextReloadTime.getTime() > currentTime.getTime()) {
-          nextReloadTime = currentTime;
+              || nextReloadTime > firstProgrammeStop) {
+          nextReloadTime = firstProgrammeStop;
         }
       });
       {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -71,12 +71,14 @@
       var table = document.createElement('table');
       table.className = 'mdl-data-table';
       var channels = {};
+      var remoconNumbers = {};
       programmes.forEach(function(programme) {
         var start = new Date(programme.start);
         var stop = new Date(programme.stop);
         if (now < stop && start < lastDate) {
           if (typeof channels[programme.name] === 'undefined') {
             channels[programme.name] = [];
+            remoconNumbers[programme.name] = programme.remocon_number;
           }
           if (actualLastDate < stop) {
             actualLastDate = stop;
@@ -117,14 +119,13 @@
         var tr = document.createElement('tr');
         var width = (100 / Object.keys(channels).length) + '%';
         Object.keys(channels).forEach(function(key) {
-          var remoconNumber = channels[key][0].remocon_number;
           var th = document.createElement('th');
-          th.classList.add(remoconNumber);
+          th.classList.add(remoconNumbers[key]);
           th.classList.add('mdl-data-table__cell--non-numeric');
           th.setAttribute('width', width);
           var anchor = document.createElement('a');
           anchor.textContent = key;
-          anchor.id = remoconNumber;
+          anchor.id = remoconNumbers[key];
           anchor.setAttribute('href', 'javascript:void(0)');
           anchor.addEventListener('click', selectChannel);
           th.appendChild(anchor);
@@ -142,7 +143,6 @@
             var start = new Date(programme.start);
             var stop = new Date(programme.stop);
             var pos = Math.floor((start - now) / 60000);
-            var remoconNumber = channels[key][0].remocon_number;
             var height;
             if (i == pos) {
               height = Math.floor((stop - start) / 60000);
@@ -152,7 +152,7 @@
             if (height > 0) {
               if ((i == 0 && j == 0) || i == pos) {
                 var td = document.createElement('td');
-                td.classList.add(remoconNumber);
+                td.classList.add(remoconNumbers[key]);
                 td.classList.add('mdl-data-table__cell--non-numeric');
                 if (programme.title == "NO DATA") {
                   td.classList.add('empty');

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -132,7 +132,6 @@
         });
         table.appendChild(tr);
       }
-      getCurrentChannel();
 
       var timeTics = Math.floor((actualLastDate - now) / 60000);
       for (var i = 0; i < timeTics; i++) {
@@ -174,6 +173,7 @@
         table.appendChild(tr);
       }
       timetable.appendChild(table);
+      getCurrentChannel();
 
       if (typeof nextReloadTime === 'undefined' || nextReloadTime.getTime() <= 0) {
         setTimeout(function() { updateProgrammes(); }, 5 * 60 * 1000);


### PR DESCRIPTION
a1cf4e8 and 88f8461 are recommended to apply, because they fix issues and provide better table layout.

39771d1, dedd11f, and 1015adb are optional; I will respect your preference.

For a2f1f35, I didn't understand why you run getCurrentChannel before building table; if that is from your intent, please ignore my commit.

9e21185 will improve the table building. I include `splice` to reduce the loop, but you can remove the statement. Note that, as it keeps `Date` objects, it may consume a bit more memory. (This commit is an improved version of f52b31f, which assumes the EPG data is sorted.)
